### PR TITLE
chore(npm): add git-commit-msg-linter as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "eslint": "^8.0.1",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
+    "git-commit-msg-linter": "^5.0.4",
     "jest": "29.3.1",
     "prettier": "^2.3.2",
     "prisma": "^4.11.0",


### PR DESCRIPTION
Já que estamos usando _conventional commits_ nas branchs, adicionei a dependência git-commit-msg-linter pra impedir de subirmos commits sem a mesmas.