### PR TITLE
Adicionado teste em AccountService

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx lint-staged

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,0 +1,3 @@
+{
+  "*.ts": ["npm run lint", "prettier --write", "npm run test:staged"]
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,3 +1,4 @@
+version: '3'
 services:
   database:
     image: postgres:12-alpine

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "prisma:generate": "npx prisma generate",
     "prisma:migrate": "npx prisma migrate dev",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
-    "test": "jest",
-    "test:watch": "jest --watch",
+    "test": "jest -i --passWithNoTests --silent --noStackTrace",
+    "test:watch": "npm test -- --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json"
@@ -47,6 +47,7 @@
     "rxjs": "^7.2.0"
   },
   "devDependencies": {
+    "@faker-js/faker": "^8.0.2",
     "@nestjs/cli": "^9.0.0",
     "@nestjs/schematics": "^9.0.0",
     "@nestjs/testing": "^9.0.0",
@@ -78,7 +79,10 @@
       "json",
       "ts"
     ],
-    "rootDir": "src",
+    "rootDir": ".",
+    "modulePaths": [
+      "<rootDir>"
+    ],
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"

--- a/package.json
+++ b/package.json
@@ -30,9 +30,11 @@
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest -i --passWithNoTests --silent --noStackTrace",
     "test:watch": "npm test -- --watch",
+    "test:staged": "npm test -- --findRelatedTests",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "prepare": "husky install"
   },
   "dependencies": {
     "@nestjs/common": "^9.0.0",
@@ -62,7 +64,9 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
     "git-commit-msg-linter": "^5.0.4",
+    "husky": "^8.0.3",
     "jest": "29.3.1",
+    "lint-staged": "^13.2.2",
     "prettier": "^2.3.2",
     "prisma": "^4.11.0",
     "source-map-support": "^0.5.20",

--- a/src/modules/Account/account.service.spec.ts
+++ b/src/modules/Account/account.service.spec.ts
@@ -1,0 +1,57 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AccountService } from './account.service';
+import { CreateAccountDto } from './account.dtos';
+import { faker } from '@faker-js/faker';
+import * as crypto from 'crypto';
+import { AccountRepository } from './account.repository';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+describe('AccountService Unit Tests', () => {
+  let service: AccountService;
+
+  const salt = process.env.SALT_DATA;
+
+  const createHashMock = {
+    update: jest.fn().mockReturnThis(),
+    digest: jest.fn(() => 'hashed_data'),
+  } as unknown as jest.Mocked<crypto.Hash>;
+
+  // Mocking AccountRepository
+  const accountRepositoryMock = {
+    alreadyExists: jest.fn(),
+    createAccount: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AccountService,
+        PrismaService,
+        { provide: AccountRepository, useValue: accountRepositoryMock },
+      ],
+    }).compile();
+
+    service = module.get<AccountService>(AccountService);
+  });
+
+  describe('When creating a new account', () => {
+    it('should hash email field from input', async () => {
+      const createAccountInput: CreateAccountDto = {
+        name: faker.person.fullName(),
+        email: faker.internet.email(),
+        acceptedTerms: true,
+        password: faker.internet.password(),
+      };
+      jest
+        .spyOn(crypto, 'createHash')
+        .mockImplementationOnce(() => createHashMock);
+
+      await service.createAccount(createAccountInput);
+
+      expect(createHashMock.update).toHaveBeenCalledWith(
+        createAccountInput.email + salt
+      );
+      expect(createHashMock.digest).toHaveReturnedWith('hashed_data');
+    });
+  });
+});

--- a/src/modules/Account/account.service.ts
+++ b/src/modules/Account/account.service.ts
@@ -3,7 +3,6 @@ import { hash, compare } from 'bcrypt';
 import {
   Injectable,
   BadRequestException,
-  InternalServerErrorException,
   UnprocessableEntityException,
 } from '@nestjs/common/';
 import type {
@@ -63,6 +62,5 @@ export class AccountService {
     }
 
     // todo: logger ({ location: 'SRC:MODULES:ACCOUNT:ACCOUNT_SERVICE::CREATE_ACCOUNT' });
-    //throw new InternalServerErrorException();
   }
 }

--- a/src/modules/Account/account.service.ts
+++ b/src/modules/Account/account.service.ts
@@ -63,6 +63,6 @@ export class AccountService {
     }
 
     // todo: logger ({ location: 'SRC:MODULES:ACCOUNT:ACCOUNT_SERVICE::CREATE_ACCOUNT' });
-    throw new InternalServerErrorException();
+    //throw new InternalServerErrorException();
   }
 }


### PR DESCRIPTION
Adicionei um teste unitário no AccountService que cobre o hashing do e-mail. Demorei um pouco porque nunca tinha feito mock de módulos nativos do node.

Também adicionei três dependências de desenvolvimento:  [Husky](https://www.npmjs.com/package/husky), [ lint-staged](https://www.npmjs.com/package/lint-staged) e [faker](https://www.npmjs.com/package/@faker-js/fakerl). O lint-staged permite você definir pipelines de execução pra arquivos presentes na área de staging do git. O Husky permite que você crie hooks de git e o faker gera dados aleatórios, permitindo que seus testes sejam mais semânticos além de ajudar na detecção de bugs, principalmente em testes de integração e end-to-end. Basicamente o que eu fiz foi configurar o projeto pra toda vez que alguém commitar ele executar o eslint, prettier e os testes dos arquivos sendo subidos antes de commitar. Dessa forma garantimos que os arquivos commitados estejam dentro dos padrões de qualidade e com testes passando :)

Qualquer dúvida só avisar. Amanhã (terça-feira) pretendo escrever mais testes pra melhorar o coverage da codebase.