### PR TITLE
Testes unitários do AccountService

### DIFF
--- a/src/modules/Account/account.service.spec.ts
+++ b/src/modules/Account/account.service.spec.ts
@@ -1,11 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AccountService } from './account.service';
-import { CreateAccountDto } from './account.dtos';
-import { faker } from '@faker-js/faker';
 import * as crypto from 'crypto';
 import { AccountRepository } from './account.repository';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { UnprocessableEntityException } from '@nestjs/common';
+import { createAccountInput } from './tests/stubs/account.stubs';
 
 describe('AccountService Unit Tests', () => {
   let service: AccountService;
@@ -37,12 +36,6 @@ describe('AccountService Unit Tests', () => {
 
   describe('When creating a new account', () => {
     it('should hash email field from input', async () => {
-      const createAccountInput: CreateAccountDto = {
-        name: faker.person.fullName(),
-        email: faker.internet.email(),
-        acceptedTerms: true,
-        password: faker.internet.password(),
-      };
       jest
         .spyOn(crypto, 'createHash')
         .mockImplementationOnce(() => createHashMock);
@@ -56,12 +49,6 @@ describe('AccountService Unit Tests', () => {
     });
 
     it('verify if user already exists by using his hashed email', async () => {
-      const createAccountInput: CreateAccountDto = {
-        name: faker.person.fullName(),
-        email: faker.internet.email(),
-        acceptedTerms: true,
-        password: faker.internet.password(),
-      };
       const accountRepositorySpy = jest.spyOn(
         accountRepositoryMock,
         'alreadyExists'
@@ -73,12 +60,6 @@ describe('AccountService Unit Tests', () => {
     });
 
     it('it throws if user already exsists', async () => {
-      const createAccountInput: CreateAccountDto = {
-        name: faker.person.fullName(),
-        email: faker.internet.email(),
-        acceptedTerms: true,
-        password: faker.internet.password(),
-      };
       jest
         .spyOn(accountRepositoryMock, 'alreadyExists')
         .mockImplementation(() => {

--- a/src/modules/Account/account.service.spec.ts
+++ b/src/modules/Account/account.service.spec.ts
@@ -53,5 +53,22 @@ describe('AccountService Unit Tests', () => {
       );
       expect(createHashMock.digest).toHaveReturnedWith('hashed_data');
     });
+
+    it('verify if user already exists by using his hashed email', async () => {
+      const createAccountInput: CreateAccountDto = {
+        name: faker.person.fullName(),
+        email: faker.internet.email(),
+        acceptedTerms: true,
+        password: faker.internet.password(),
+      };
+      const accountRepositorySpy = jest.spyOn(
+        accountRepositoryMock,
+        'alreadyExists'
+      );
+
+      await service.createAccount(createAccountInput);
+
+      expect(accountRepositorySpy).toHaveBeenCalledWith('hashed_data');
+    });
   });
 });

--- a/src/modules/Account/account.service.spec.ts
+++ b/src/modules/Account/account.service.spec.ts
@@ -19,7 +19,7 @@ describe('AccountService Unit Tests', () => {
 
   const createHashMock = {
     update: jest.fn().mockReturnThis(),
-    digest: jest.fn(() => 'hashed_data'),
+    digest: jest.fn(() => 'hashed_email'),
   } as unknown as jest.Mocked<crypto.Hash>;
 
   const accountRepositoryMock = {
@@ -50,7 +50,7 @@ describe('AccountService Unit Tests', () => {
       expect(createHashMock.update).toHaveBeenCalledWith(
         createAccountInput.email + salt
       );
-      expect(createHashMock.digest).toHaveReturnedWith('hashed_data');
+      expect(createHashMock.digest).toHaveReturnedWith('hashed_email');
     });
 
     it('verify if user already exists by using his hashed email', async () => {
@@ -61,7 +61,7 @@ describe('AccountService Unit Tests', () => {
 
       await service.createAccount(createAccountInput);
 
-      expect(accountRepositorySpy).toHaveBeenCalledWith('hashed_data');
+      expect(accountRepositorySpy).toHaveBeenCalledWith('hashed_email');
     });
 
     it('it throws if user already exists', async () => {
@@ -92,6 +92,29 @@ describe('AccountService Unit Tests', () => {
         createAccountInput.password,
         saltRounds
       );
+    });
+
+    it('it should create a new account with correct data', async () => {
+      // hashing password
+      jest.spyOn(bcrypt, 'hash').mockImplementation(() => {
+        return new Promise((resolve) => resolve('hashed_password'));
+      });
+      // hashing email
+      jest
+        .spyOn(crypto, 'createHash')
+        .mockImplementationOnce(() => createHashMock);
+      const accountRepositorySpy = jest.spyOn(
+        accountRepositoryMock,
+        'createAccount'
+      );
+
+      await service.createAccount(createAccountInput);
+
+      expect(accountRepositorySpy).toHaveBeenCalledWith({
+        email: 'hashed_email',
+        password: 'hashed_password',
+        name: createAccountInput.name,
+      });
     });
   });
 });

--- a/src/modules/Account/account.service.ts
+++ b/src/modules/Account/account.service.ts
@@ -5,11 +5,9 @@ import {
   BadRequestException,
   UnprocessableEntityException,
 } from '@nestjs/common/';
-import type {
-  ICreateAccountExpect,
-  ICreateAccountResponse,
-} from 'src/types/account';
+import type { ICreateAccountResponse } from 'src/types/account';
 import { AccountRepository } from './account.repository';
+import { CreateAccountDto } from './account.dtos';
 
 @Injectable()
 export class AccountService {
@@ -33,13 +31,13 @@ export class AccountService {
   }
 
   async createAccount(
-    data: ICreateAccountExpect
+    createAccountInput: CreateAccountDto
   ): Promise<ICreateAccountResponse> {
-    if (data.acceptedTerms !== true) {
+    if (createAccountInput.acceptedTerms !== true) {
       throw new BadRequestException('Please accept our privacy policies');
     }
 
-    const hashedEmail = this.hashData(data.email);
+    const hashedEmail = this.hashData(createAccountInput.email);
     const alreadyExists = await this.accountRepository.alreadyExists(
       hashedEmail
     );
@@ -48,11 +46,11 @@ export class AccountService {
       throw new UnprocessableEntityException('This e-mail already exists');
     }
 
-    const hashedPassword = await this.hashPassword(data.password);
+    const hashedPassword = await this.hashPassword(createAccountInput.password);
     const created = await this.accountRepository.createAccount({
       email: hashedEmail,
       password: hashedPassword,
-      name: data.name,
+      name: createAccountInput.name,
     });
 
     if (created) {

--- a/src/modules/Account/tests/stubs/account.stubs.ts
+++ b/src/modules/Account/tests/stubs/account.stubs.ts
@@ -1,0 +1,9 @@
+import { CreateAccountDto } from '../../account.dtos';
+import { faker } from '@faker-js/faker';
+
+export const createAccountInput: CreateAccountDto = {
+  name: faker.person.fullName(),
+  email: faker.internet.email(),
+  acceptedTerms: true,
+  password: faker.internet.password(),
+};


### PR DESCRIPTION
Finalizei os testes unitários do AccountService. Também fiz uma pequena mudança no parâmetro que o createAccount() recebe para usar um DTO invés de um tipo. Usei um DTO porque eles servem justamente para modelar entradas e saídas de dados entre componentes.