### PR TITLE
test: session service

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,1 +1,0 @@
-export const CREDENTIALS_KEY = 'account.credentials';

--- a/src/guards/roles.guard.ts
+++ b/src/guards/roles.guard.ts
@@ -10,7 +10,7 @@ import { Reflector } from '@nestjs/core';
 import { Request } from 'express';
 import { SessionService } from 'src/modules/Session/session.service';
 import { RoleLevel, Permissions } from './roles.config';
-import { CREDENTIALS_KEY } from 'src/config';
+import { CREDENTIALS_KEY } from 'src/utils/constants';
 
 @Injectable()
 export class RolesGuard implements CanActivate {

--- a/src/modules/Account/account.controller.ts
+++ b/src/modules/Account/account.controller.ts
@@ -20,7 +20,7 @@ import {
 import { AccountService } from './account.service';
 import { SessionService } from '../Session/session.service';
 import { Permissions, RequirePermissions, RolesGuard } from 'src/guards';
-import { CREDENTIALS_KEY } from 'src/config';
+import { CREDENTIALS_KEY } from 'src/utils/constants';
 
 @UseGuards(RolesGuard)
 @ApiTags('Authentication routes')

--- a/src/modules/Session/session.service.spec.ts
+++ b/src/modules/Session/session.service.spec.ts
@@ -1,0 +1,64 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SessionService } from './session.service';
+import { SessionRepository } from './session.repository';
+
+import { faker } from '@faker-js/faker';
+import { CreateSessionServiceInput } from './session.dtos';
+import { RoleLevel } from 'src/guards';
+
+const createServiceInput: CreateSessionServiceInput = {
+  accountId: faker.string.uuid(),
+  name: faker.person.fullName(),
+  permissions: RoleLevel.Standard,
+  remember: faker.datatype.boolean(),
+};
+
+describe('SessionService unit test', () => {
+  let service: SessionService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SessionService,
+        {
+          provide: SessionRepository,
+          useValue: {
+            createSession: jest.fn().mockResolvedValue(true),
+            findSessionByToken: jest.fn(),
+            findExpiredSessionByToken: jest.fn(),
+            updateSession: jest.fn(),
+            excludeAllSessions: jest.fn(),
+            excludeSession: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<SessionService>(SessionService);
+  });
+
+  it('Should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('Create session', () => {
+    it('Happy path - should return a SessionServiceOutput', async () => {
+      const actual = await service.createSession(createServiceInput);
+      const { name, remember, permissions } = createServiceInput;
+      const diff = remember ? 36e5 * 24 * 7 : 36e5;
+      const expiresInExpected = new Date(new Date().getTime() + diff);
+      const hexadecimalRegex = /^[a-f0-9]+$/;
+
+      expect(actual.name).toEqual(name);
+      expect(actual.token).toMatch(hexadecimalRegex);
+      expect(actual.refreshToken).toMatch(hexadecimalRegex);
+      expect(actual.permissions).toEqual(permissions);
+      expect(actual.expiresIn.getTime()).toBeLessThanOrEqual(
+        expiresInExpected.getTime()
+      );
+      expect(actual.expiresIn.getTime()).toBeGreaterThanOrEqual(
+        expiresInExpected.getTime() - 10
+      );
+    });
+  });
+});

--- a/src/modules/Session/session.service.spec.ts
+++ b/src/modules/Session/session.service.spec.ts
@@ -3,7 +3,7 @@ import { SessionService } from './session.service';
 import { SessionRepository } from './session.repository';
 
 import * as constants from 'src/utils/constants';
-import * as stubs from './session.stubs.test';
+import * as stubs from './tests/session.stubs';
 import { InternalServerErrorException } from '@nestjs/common';
 
 describe('SessionService unit test', () => {

--- a/src/modules/Session/session.service.spec.ts
+++ b/src/modules/Session/session.service.spec.ts
@@ -2,16 +2,8 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { SessionService } from './session.service';
 import { SessionRepository } from './session.repository';
 
-import { faker } from '@faker-js/faker';
-import { CreateSessionServiceInput } from './session.dtos';
-import { RoleLevel } from 'src/guards';
-
-const createServiceInput: CreateSessionServiceInput = {
-  accountId: faker.string.uuid(),
-  name: faker.person.fullName(),
-  permissions: RoleLevel.Standard,
-  remember: faker.datatype.boolean(),
-};
+import * as constants from 'src/utils/constants';
+import * as stubs from './session.stubs.test';
 
 describe('SessionService unit test', () => {
   let service: SessionService;
@@ -43,11 +35,13 @@ describe('SessionService unit test', () => {
 
   describe('Create session', () => {
     it('Happy path - should return a SessionServiceOutput', async () => {
-      const actual = await service.createSession(createServiceInput);
-      const { name, remember, permissions } = createServiceInput;
-      const diff = remember ? 36e5 * 24 * 7 : 36e5;
+      const actual = await service.createSession(stubs.createInput);
+      const { name, remember, permissions } = stubs.createInput;
+      const diff = remember
+        ? constants.expirationWhenRememberIsOnn
+        : constants.expirationWhenRememberIsOff;
       const expiresInExpected = new Date(new Date().getTime() + diff);
-      const hexadecimalRegex = /^[a-f0-9]+$/;
+      const hexadecimalRegex = constants.hexadecimalRegex;
 
       expect(actual.name).toEqual(name);
       expect(actual.token).toMatch(hexadecimalRegex);

--- a/src/modules/Session/session.service.spec.ts
+++ b/src/modules/Session/session.service.spec.ts
@@ -85,7 +85,7 @@ describe('SessionService unit test', () => {
       expect(actual).toEqual(stubs.findByTokenOutput);
     });
 
-    it('Unhappy path - should return a UnauthorizedException', async () => {
+    it(`Unhappy path - should return a error message: "${stubs.expectedMessages.sessionExpired}"`, async () => {
       jest
         .spyOn(sessionRepositoryMock, 'findSessionByToken')
         .mockResolvedValueOnce(false);
@@ -93,7 +93,7 @@ describe('SessionService unit test', () => {
       try {
         await service.findSessionToken(stubs.findByTokenInput.token);
       } catch (actual) {
-        expect(actual.message).toEqual('Session expired');
+        expect(actual.message).toEqual(stubs.expectedMessages.sessionExpired);
         expect(actual).toBeInstanceOf(UnauthorizedException);
       }
     });
@@ -115,7 +115,7 @@ describe('SessionService unit test', () => {
       expect(actual.refreshToken).not.toEqual(refreshToken);
     });
 
-    it('Unhappy path - should return a a error message: "This session has expired or does not exist"', async () => {
+    it(`Unhappy path - should return a error message: "${stubs.expectedMessages.expiredOrDeleted}"`, async () => {
       jest
         .spyOn(sessionRepositoryMock, 'findExpiredSessionByToken')
         .mockResolvedValueOnce(null);
@@ -123,21 +123,21 @@ describe('SessionService unit test', () => {
       try {
         await service.findExpiredSessionByTokenAndRefreshToken('', '');
       } catch (actual) {
-        expect(actual.message).toEqual(
-          'This session has expired or does not exist'
-        );
+        expect(actual.message).toEqual(stubs.expectedMessages.expiredOrDeleted);
         expect(actual).toBeInstanceOf(UnauthorizedException);
       }
     });
 
-    it('Unhappy path - should return a error message: "Invalid credentials"', async () => {
+    it(`Unhappy path - should return a error message: "${stubs.expectedMessages.invalidCredentials}"`, async () => {
       try {
         await service.findExpiredSessionByTokenAndRefreshToken(
           stubs.findExpiredByTokenInput.token,
           'invalidtoken'
         );
       } catch (actual) {
-        expect(actual.message).toEqual('Invalid credentials');
+        expect(actual.message).toEqual(
+          stubs.expectedMessages.invalidCredentials
+        );
         expect(actual).toBeInstanceOf(UnauthorizedException);
       }
     });

--- a/src/modules/Session/session.service.spec.ts
+++ b/src/modules/Session/session.service.spec.ts
@@ -142,4 +142,20 @@ describe('SessionService unit test', () => {
       }
     });
   });
+
+  describe('Close sessions', () => {
+    it(`Happy path - should return a message: "${stubs.expectedMessages.aClosedSession}"`, async () => {
+      const actual = await service.closeSession(stubs.closeASessionInput);
+
+      expect(actual).toBeInstanceOf(Object);
+      expect(actual.message).toEqual(stubs.expectedMessages.aClosedSession);
+    });
+
+    it(`Happy path - should return a message: "${stubs.expectedMessages.manySessionClosed}"`, async () => {
+      const actual = await service.closeSession(stubs.closeManySessionInput);
+
+      expect(actual).toBeInstanceOf(Object);
+      expect(actual.message).toEqual(stubs.expectedMessages.manySessionClosed);
+    });
+  });
 });

--- a/src/modules/Session/session.stubs.test.ts
+++ b/src/modules/Session/session.stubs.test.ts
@@ -1,0 +1,10 @@
+import { faker } from '@faker-js/faker';
+import { CreateSessionServiceInput } from './session.dtos';
+import { RoleLevel } from 'src/guards';
+
+export const createInput: CreateSessionServiceInput = {
+  accountId: faker.string.uuid(),
+  name: faker.person.fullName(),
+  permissions: RoleLevel.Standard,
+  remember: faker.datatype.boolean(),
+};

--- a/src/modules/Session/tests/session.stubs.ts
+++ b/src/modules/Session/tests/session.stubs.ts
@@ -2,6 +2,7 @@ import { faker } from '@faker-js/faker';
 import { RoleLevel } from 'src/guards';
 import {
   CreateSessionServiceInput,
+  ExcludeSessionsServiceInput,
   FindExpiredSessionRepositoryOutput,
   FindSessionRepositoryOutpout,
 } from '../session.dtos';
@@ -19,6 +20,8 @@ export const expectedMessages = {
   sessionExpired: 'Session expired',
   invalidCredentials: 'Invalid credentials',
   expiredOrDeleted: 'This session has expired or does not exist',
+  manySessionClosed: 'Closed sessions',
+  aClosedSession: 'Session closed',
 };
 
 export const createInput: CreateSessionServiceInput = {
@@ -44,4 +47,15 @@ export const findExpiredByTokenOutput: FindExpiredSessionRepositoryOutput = {
   id: sessionId,
   refreshToken: hashData(refreshToken, process.env.SALT_SESSION),
   remember,
+};
+
+export const closeASessionInput: ExcludeSessionsServiceInput = {
+  accountId,
+  sessionToken: token,
+  closeAllSessions: false,
+};
+
+export const closeManySessionInput = {
+  ...closeASessionInput,
+  closeAllSessions: true,
 };

--- a/src/modules/Session/tests/session.stubs.ts
+++ b/src/modules/Session/tests/session.stubs.ts
@@ -15,6 +15,12 @@ const refreshToken = faker.string.hexadecimal({ length: 20 });
 const remember = faker.datatype.boolean();
 const username = faker.person.fullName();
 
+export const expectedMessages = {
+  sessionExpired: 'Session expired',
+  invalidCredentials: 'Invalid credentials',
+  expiredOrDeleted: 'This session has expired or does not exist',
+};
+
 export const createInput: CreateSessionServiceInput = {
   accountId,
   permissions,

--- a/src/modules/Session/tests/session.stubs.ts
+++ b/src/modules/Session/tests/session.stubs.ts
@@ -2,24 +2,40 @@ import { faker } from '@faker-js/faker';
 import { RoleLevel } from 'src/guards';
 import {
   CreateSessionServiceInput,
-  FindSessionServiceOutput,
+  FindExpiredSessionRepositoryOutput,
+  FindSessionRepositoryOutpout,
 } from '../session.dtos';
+import { hashData } from 'src/utils/hashes';
 
+const sessionId = faker.number.int();
 const accountId = faker.string.uuid();
 const permissions = RoleLevel.Standard;
+const token = faker.string.hexadecimal({ length: 20 });
+const refreshToken = faker.string.hexadecimal({ length: 20 });
+const remember = faker.datatype.boolean();
+const username = faker.person.fullName();
 
 export const createInput: CreateSessionServiceInput = {
   accountId,
   permissions,
-  name: faker.person.fullName(),
-  remember: faker.datatype.boolean(),
+  remember,
+  name: username,
 };
 
-export const findByTokenInput = {
-  token: faker.string.hexadecimal(),
-};
+export const findByTokenInput = { token };
 
-export const findByTokenOutput: FindSessionServiceOutput = {
+export const findByTokenOutput: FindSessionRepositoryOutpout = {
   accountId,
   permissions,
+};
+
+export const findExpiredByTokenInput = {
+  token,
+  refreshToken,
+};
+
+export const findExpiredByTokenOutput: FindExpiredSessionRepositoryOutput = {
+  id: sessionId,
+  refreshToken: hashData(refreshToken, process.env.SALT_SESSION),
+  remember,
 };

--- a/src/modules/Session/tests/session.stubs.ts
+++ b/src/modules/Session/tests/session.stubs.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import { CreateSessionServiceInput } from './session.dtos';
+import { CreateSessionServiceInput } from '../session.dtos';
 import { RoleLevel } from 'src/guards';
 
 export const createInput: CreateSessionServiceInput = {

--- a/src/modules/Session/tests/session.stubs.ts
+++ b/src/modules/Session/tests/session.stubs.ts
@@ -5,10 +5,13 @@ import {
   FindSessionServiceOutput,
 } from '../session.dtos';
 
+const accountId = faker.string.uuid();
+const permissions = RoleLevel.Standard;
+
 export const createInput: CreateSessionServiceInput = {
-  accountId: faker.string.uuid(),
+  accountId,
+  permissions,
   name: faker.person.fullName(),
-  permissions: RoleLevel.Standard,
   remember: faker.datatype.boolean(),
 };
 
@@ -17,6 +20,6 @@ export const findByTokenInput = {
 };
 
 export const findByTokenOutput: FindSessionServiceOutput = {
-  accountId: faker.string.uuid(),
-  permissions: RoleLevel.Standard,
+  accountId,
+  permissions,
 };

--- a/src/modules/Session/tests/session.stubs.ts
+++ b/src/modules/Session/tests/session.stubs.ts
@@ -1,10 +1,22 @@
 import { faker } from '@faker-js/faker';
-import { CreateSessionServiceInput } from '../session.dtos';
 import { RoleLevel } from 'src/guards';
+import {
+  CreateSessionServiceInput,
+  FindSessionServiceOutput,
+} from '../session.dtos';
 
 export const createInput: CreateSessionServiceInput = {
   accountId: faker.string.uuid(),
   name: faker.person.fullName(),
   permissions: RoleLevel.Standard,
   remember: faker.datatype.boolean(),
+};
+
+export const findByTokenInput = {
+  token: faker.string.hexadecimal(),
+};
+
+export const findByTokenOutput: FindSessionServiceOutput = {
+  accountId: faker.string.uuid(),
+  permissions: RoleLevel.Standard,
 };

--- a/src/modules/Task/task.controller.ts
+++ b/src/modules/Task/task.controller.ts
@@ -15,7 +15,7 @@ import {
 } from '@nestjs/common';
 import { TaskService } from './task.service';
 import { CreateTaskInput, UpdateTaskInput } from './task.dtos';
-import { CREDENTIALS_KEY } from 'src/config';
+import { CREDENTIALS_KEY } from 'src/utils/constants';
 import { RequirePermissions, Permissions, RolesGuard } from 'src/guards';
 
 @Controller('tasks')

--- a/src/utils/constants/index.ts
+++ b/src/utils/constants/index.ts
@@ -1,0 +1,4 @@
+export const CREDENTIALS_KEY = 'account.credentials';
+export const hexadecimalRegex = /^[a-f0-9]+$/;
+export const expirationWhenRememberIsOnn = 36e5 * 24 * 7;
+export const expirationWhenRememberIsOff = 36e5;

--- a/src/utils/hashes.ts
+++ b/src/utils/hashes.ts
@@ -1,14 +1,17 @@
 import { createHash } from 'node:crypto';
 
+const algorithm = 'sha256';
+const digest = 'hex';
+
 export function hashDataAsync(
   unhashedData: string,
   salt: string
 ): Promise<string> {
   return new Promise((resolve, reject) => {
     try {
-      const hashedData = createHash('sha256')
+      const hashedData = createHash(algorithm)
         .update(unhashedData + salt)
-        .digest('hex');
+        .digest(digest);
 
       resolve(hashedData);
     } catch (error) {
@@ -16,4 +19,10 @@ export function hashDataAsync(
       reject(null);
     }
   });
+}
+
+export function hashData(unhashedData: string, salt: string): string {
+  return createHash(algorithm)
+    .update(unhashedData + salt)
+    .digest(digest);
 }


### PR DESCRIPTION
- SessionService unit test
  - √ Should be defined (17 ms)
  - Create session
      - √ Happy path - should return a SessionServiceOutput (6 ms)
      - √ Unhappy path - should return a InternalServerError (4 ms)
  - Find session by token
     - √ Happy path - should return a FindSessionServiceOutput (6 ms)
     - √ Unhappy path - should return a error message: "Session expired" (7 ms)
  - Find expired session by token and refresh token
     - √ Happy path - should return a RefreshTokenServiceOutput (7 ms)
     - √ Unhappy path - should return a error message: "This session has expired or does not exist" (3 ms)
     - √ Unhappy path - should return a error message: "Invalid credentials" (3 ms)
  - Close sessions
     - √ Happy path - should return a message: "Session closed" (4 ms)
     - √ Happy path - should return a message: "Closed sessions" (8 ms)