### PR TITLE
feat(auth): Add Password Reset Validation Endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@nestjs/common": "^9.0.0",
+    "@nestjs/config": "^3.1.1",
     "@nestjs/core": "^9.0.0",
     "@nestjs/platform-express": "^9.0.0",
     "@nestjs/swagger": "^7.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,7 +1,13 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { AccountModule, TaskModule, GoalModule } from './modules';
 
 @Module({
-  imports: [AccountModule, TaskModule, GoalModule],
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    AccountModule,
+    TaskModule,
+    GoalModule,
+  ],
 })
 export class AppModule {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { NestFactory } from '@nestjs/core';
 import { SwaggerModule } from '@nestjs/swagger';
+import { ConfigService } from '@nestjs/config';
 import helmet from 'helmet';
 
 import ValidationPipe from './config/validation-pipe';
@@ -9,6 +10,8 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  const configService = app.get(ConfigService);
+  const port = configService.get<string>('PORT');
 
   app.use(helmet());
   app.enableCors(corsOptionsConfig);
@@ -17,8 +20,8 @@ async function bootstrap() {
   const document = SwaggerModule.createDocument(app, swaggerDocumentConfig);
   SwaggerModule.setup('', app, document);
 
-  await app.listen(process.env.PORT, () => {
-    console.log(`[ONN] Port: ${process.env.PORT}`);
+  await app.listen(port, () => {
+    console.log(`[ONN] Port: ${port}`);
   });
 }
 

--- a/src/modules/Account/account.controller.ts
+++ b/src/modules/Account/account.controller.ts
@@ -1,3 +1,4 @@
+import { VerifyCodeInput } from './../PasswordToken/passwordToken.dtos';
 import { Request } from 'express';
 import {
   Controller,
@@ -7,6 +8,8 @@ import {
   UseGuards,
   HttpCode,
   Req,
+  Get,
+  Query,
 } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import {
@@ -123,11 +126,23 @@ export class AccountController {
   }
 
   @ApiTags('Password reset')
+  @Get('validatecode')
+  @RequirePermissions([Permissions['001']])
+  async validateCode(@Query() verifyCodeInput: VerifyCodeInput) {
+    try {
+      return await this.accountService.validateCode(verifyCodeInput);
+    } catch (e) {
+      throw e;
+    }
+  }
+
+  @ApiTags('Password reset')
   @Put('changepassword')
   @RequirePermissions([Permissions['001']])
   async changePassword(@Body() changePasswordInput: ChangePasswordInput) {
     try {
-      return await this.accountService.changePassword(changePasswordInput);
+      await this.accountService.changePassword(changePasswordInput);
+      return { message: 'Senha alterada com sucesso' };
     } catch (e) {
       throw e;
     }

--- a/src/modules/Account/account.controller.ts
+++ b/src/modules/Account/account.controller.ts
@@ -1,4 +1,3 @@
-import { VerifyCodeInput } from './../PasswordToken/passwordToken.dtos';
 import { Request } from 'express';
 import {
   Controller,
@@ -8,8 +7,6 @@ import {
   UseGuards,
   HttpCode,
   Req,
-  Get,
-  Query,
 } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import {
@@ -132,7 +129,7 @@ export class AccountController {
   async validateCode(@Body() validateTokenInput: ValidateTokenInput) {
     try {
       await this.accountService.validateCode(validateTokenInput);
-      return {message: 'Validação bem-sucedida!'}
+      return { message: 'Validação bem-sucedida!' };
     } catch (e) {
       throw e;
     }

--- a/src/modules/Account/account.controller.ts
+++ b/src/modules/Account/account.controller.ts
@@ -19,6 +19,7 @@ import {
   ResetPasswordInput,
   ChangePasswordInput,
   DisconnectAccountControllerInput,
+  ValidateTokenInput,
 } from './account.dtos';
 import { AccountService } from './account.service';
 import { SessionService } from '../Session/session.service';
@@ -125,12 +126,13 @@ export class AccountController {
     }
   }
 
-  @ApiTags('Password reset')
-  @Get('validatecode')
+  @ApiTags('Validate code')
+  @Post('validatecode')
   @RequirePermissions([Permissions['001']])
-  async validateCode(@Query() verifyCodeInput: VerifyCodeInput) {
+  async validateCode(@Body() validateTokenInput: ValidateTokenInput) {
     try {
-      return await this.accountService.validateCode(verifyCodeInput);
+      await this.accountService.validateCode(validateTokenInput);
+      return {message: 'Validação bem-sucedida!'}
     } catch (e) {
       throw e;
     }

--- a/src/modules/Account/account.dtos.ts
+++ b/src/modules/Account/account.dtos.ts
@@ -138,3 +138,15 @@ export class ChangePasswordRepositoryInput {
   password: string;
   accountId: string;
 }
+
+export class ValidateTokenInput {
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsString()
+  code: string;
+
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsString()
+  accountId: string;
+}

--- a/src/modules/Account/account.dtos.ts
+++ b/src/modules/Account/account.dtos.ts
@@ -116,14 +116,8 @@ export class ResetPasswordOutput {
 export class ChangePasswordInput {
   @ApiProperty()
   @IsNotEmpty()
-  @IsStrongPassword()
+  @IsStrongPassword({minLength: 6})
   password: string;
-
-  @ApiProperty()
-  @IsNotEmpty()
-  @IsStrongPassword()
-  @IsEqualTo('password')
-  repeatPassword: string;
 
   @ApiProperty()
   @IsNotEmpty()

--- a/src/modules/Account/account.dtos.ts
+++ b/src/modules/Account/account.dtos.ts
@@ -8,7 +8,6 @@ import {
   IsHexadecimal,
   IsString,
 } from 'class-validator';
-import { IsEqualTo } from 'src/utils/decorators/isEqualTo';
 import { responses } from 'src/config/responses';
 
 class AccountBaseDto {
@@ -116,7 +115,7 @@ export class ResetPasswordOutput {
 export class ChangePasswordInput {
   @ApiProperty()
   @IsNotEmpty()
-  @IsStrongPassword({minLength: 6})
+  @IsStrongPassword({ minLength: 6 })
   password: string;
 
   @ApiProperty()

--- a/src/modules/Account/account.service.spec.ts
+++ b/src/modules/Account/account.service.spec.ts
@@ -277,7 +277,6 @@ describe('AccountService Unit Tests', () => {
     const changePasswordInput = {
       code: '123789',
       password: 'new_password',
-      repeatPassword: 'new_password',
       accountId: faker.string.uuid(),
     };
     jest.spyOn(tokenServiceMock, 'verifyToken').mockResolvedValue(true);

--- a/src/modules/Account/account.service.ts
+++ b/src/modules/Account/account.service.ts
@@ -140,9 +140,20 @@ export class AccountService {
   async changePassword(
     changePasswordInput: ChangePasswordInput
   ): Promise<void> {
-    const { accountId, password } = changePasswordInput;
+    const { accountId, password, code } = changePasswordInput;
 
     const hashedPassword = await this.hashPassword(password);
+
+    const isValid = await this.tokenService.verifyToken({
+      code,
+      accountId,
+    });
+
+    if (!isValid) {
+      throw new AuthorizationError({
+        message: 'Código inválido',
+      });
+    }
 
     await this.accountRepository.changePassword({
       password: hashedPassword,

--- a/src/modules/PasswordToken/passwordToken.service.ts
+++ b/src/modules/PasswordToken/passwordToken.service.ts
@@ -48,6 +48,11 @@ export class PasswordTokenService {
     const token = await this.repository.findByAccountId(
       verifyCodeInput.accountId
     );
+
+    if (!token) {
+      return false;
+    }
+
     const isEqual = await bcrypt.compare(verifyCodeInput.code, token.token);
 
     return isEqual;


### PR DESCRIPTION
## Descrição

Este pull request introduz um novo endpoint para validação de redefinição de senha na autenticação.

## Alterações Propostas

- Adiciona um novo endpoint Get ('validatecode') no controlador para lidar com a validação de códigos de redefinição de senha.
- A nova rota chama o método validateCode do serviço de conta (AccountService).
- O método validateCode utiliza o TokenService para verificar um código fornecido em VerifyCodeInput.
- Se o código não for válido, ele lança um NotFoundError com uma mensagem correspondente.
- Esta adição melhora o processo de redefinição de senha, permitindo aos usuários validar códigos para recuperação de senha.

## Contexto Adicional

Esta alteração está relacionada aos commits anteriores que introduziram melhorias na validação de código e redefinição de senha no projeto.

## Issues Relacionadas

Fixes #62
